### PR TITLE
Reformat code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/TakoLog
+/vendor

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/hasegaw/TakoLog
+
+go 1.13
+
+require gocv.io/x/gocv v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+gocv.io/x/gocv v0.21.0 h1:dVjagrupZrfCRY0qPEaYWgoNMRpBel6GYDH4mvQOK8Y=
+gocv.io/x/gocv v0.21.0/go.mod h1:Rar2PS6DV+T4FL+PM535EImD/h13hGVaHhnCu1xarBs=

--- a/spl2.go
+++ b/spl2.go
@@ -13,12 +13,12 @@ import (
 	"github.com/hasegaw/TakoLog/src/utils"
 )
 
-func process_video() {
-	win_matched := gocv.NewWindow("Matched")
-	win_scoreboard := gocv.NewWindow("Scoreboard")
+func processVideo() {
+	winMatched := gocv.NewWindow("Matched")
+	winScoreboard := gocv.NewWindow("Scoreboard")
 
 	img1 := utils.IMRead720p("result.jpg")
-	feature1 := scoreboard.Extract_feature(img1)
+	feature1 := scoreboard.ExtractFeature(img1)
 
 	var webcam *gocv.VideoCapture
 	var err error
@@ -30,7 +30,7 @@ func process_video() {
 
 	fmt.Println(err)
 	img := gocv.NewMat()
-	img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
+	img720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
 	for {
 		for i := 0; i < 10; i++ {
 			webcam.Read(&img)
@@ -39,18 +39,18 @@ func process_video() {
 		//     break
 		// }
 
-		gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
-		if scoreboard.Match_result(img_720p, feature1) {
+		gocv.Resize(img, &img720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
+		if scoreboard.MatchResult(img720p, feature1) {
 			fmt.Println("Found scoreboard")
-			win_scoreboard.IMShow(img_720p)
-			win_scoreboard.WaitKey(1)
+			winScoreboard.IMShow(img720p)
+			winScoreboard.WaitKey(1)
 			return
 		}
 
-		if lobby.Match_result(img_720p) {
+		if lobby.MatchResult(img720p) {
 			fmt.Println("Found lobby_matched")
-			win_matched.IMShow(img_720p)
-			win_matched.WaitKey(0)
+			winMatched.IMShow(img720p)
+			winMatched.WaitKey(0)
 		}
 	}
 }
@@ -62,5 +62,5 @@ func main() {
 		log.Fatal("")
 	}
 
-	process_video()
+	processVideo()
 }

--- a/spl2.go
+++ b/spl2.go
@@ -1,69 +1,66 @@
 package main
 
 import (
-    "os"
-    "log"
-    "fmt"
+	"fmt"
+	"log"
+	"os"
 
-    "gocv.io/x/gocv"
-    "image"
+	"gocv.io/x/gocv"
+	"image"
 
-    "github.com/hasegaw/TakoLog/src/utils"
-    "github.com/hasegaw/TakoLog/src/scenes/result/scoreboard"
-    "github.com/hasegaw/TakoLog/src/scenes/lobby"
+	"github.com/hasegaw/TakoLog/src/scenes/lobby"
+	"github.com/hasegaw/TakoLog/src/scenes/result/scoreboard"
+	"github.com/hasegaw/TakoLog/src/utils"
 )
 
-
 func process_video() {
-    win_matched := gocv.NewWindow("Matched")
-    win_scoreboard := gocv.NewWindow("Scoreboard")
+	win_matched := gocv.NewWindow("Matched")
+	win_scoreboard := gocv.NewWindow("Scoreboard")
 
-    img1 := utils.IMRead720p("result.jpg")
-    feature1 := scoreboard.Extract_feature(img1)
+	img1 := utils.IMRead720p("result.jpg")
+	feature1 := scoreboard.Extract_feature(img1)
 
-    var webcam *gocv.VideoCapture
-    var err error
-    if len(os.Args) == 1 {
-        webcam, err = gocv.VideoCaptureDevice(0)
-    } else {
-        webcam, err = gocv.VideoCaptureFile(os.Args[1])
-    }
+	var webcam *gocv.VideoCapture
+	var err error
+	if len(os.Args) == 1 {
+		webcam, err = gocv.VideoCaptureDevice(0)
+	} else {
+		webcam, err = gocv.VideoCaptureFile(os.Args[1])
+	}
 
-    fmt.Println(err)
+	fmt.Println(err)
 	img := gocv.NewMat()
-    img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
+	img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
 	for {
-        for i := 0; i < 10; i++ {
-            webcam.Read(&img)
-        }
-//        if img.Rows() == 0 {
-//            break
-//        }
+		for i := 0; i < 10; i++ {
+			webcam.Read(&img)
+		}
+		// if img.Rows() == 0 {
+		//     break
+		// }
 
-        gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
-        if scoreboard.Match_result(img_720p, feature1) {
-            fmt.Println("Found scoreboard")
-            win_scoreboard.IMShow(img_720p)
-            win_scoreboard.WaitKey(1)
-            return
-        }
+		gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
+		if scoreboard.Match_result(img_720p, feature1) {
+			fmt.Println("Found scoreboard")
+			win_scoreboard.IMShow(img_720p)
+			win_scoreboard.WaitKey(1)
+			return
+		}
 
-        if lobby.Match_result(img_720p) {
-            fmt.Println("Found lobby_matched")
-            win_matched.IMShow(img_720p)
-            win_matched.WaitKey(0)
-        }
+		if lobby.Match_result(img_720p) {
+			fmt.Println("Found lobby_matched")
+			win_matched.IMShow(img_720p)
+			win_matched.WaitKey(0)
+		}
 	}
 }
 
-
 func main() {
-    img := utils.IMRead720p("masks/spl2_result_scoreboard.jpg")
+	img := utils.IMRead720p("masks/spl2_result_scoreboard.jpg")
 
-    if img.Empty() {
-        log.Fatal("")
-    }
+	if img.Empty() {
+		log.Fatal("")
+	}
 
-    process_video()
+	process_video()
 }
-

--- a/spl2.go
+++ b/spl2.go
@@ -8,9 +8,9 @@ import (
     "gocv.io/x/gocv"
     "image"
 
-    "utils"
-    "scenes/result/scoreboard"
-    "scenes/lobby"
+    "github.com/hasegaw/TakoLog/src/utils"
+    "github.com/hasegaw/TakoLog/src/scenes/result/scoreboard"
+    "github.com/hasegaw/TakoLog/src/scenes/lobby"
 )
 
 

--- a/src/scenes/lobby/lobby.go
+++ b/src/scenes/lobby/lobby.go
@@ -1,64 +1,61 @@
 package lobby
 
 import (
-//    "fmt"
-    "gocv.io/x/gocv"
-    "image"
-    "image/color"
+	// "fmt"
+	"gocv.io/x/gocv"
+	"image"
+	"image/color"
 
-    "github.com/hasegaw/TakoLog/src/utils"
+	"github.com/hasegaw/TakoLog/src/utils"
 )
 
 var feat_matched gocv.Mat
 var done = false
 
-
 func Extract_feature(img gocv.Mat) gocv.Mat {
-    img_win_bgr := img.Region(image.Rect(848, 32, 848+200, 32+32))
-    img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
-    img_win_v   := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-    img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-    gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
-    gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
-    gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
+	img_win_bgr := img.Region(image.Rect(848, 32, 848+200, 32+32))
+	img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
+	img_win_v := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
+	gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
+	gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
 
-    return img_win_v_norm
+	return img_win_v_norm
 }
 
 func Match_result(img gocv.Mat) bool {
-    if done {
-        return false
-    }
+	if done {
+		return false
+	}
 
-    img1 := img
-    feature1 := Extract_feature(img1)
-    feature2 := feat_matched
+	img1 := img
+	feature1 := Extract_feature(img1)
+	feature2 := feat_matched
 
-    result := gocv.NewMatWithSize(1, 1, gocv.MatTypeCV32F)
-    mask_1 := gocv.NewMatWithSize(feature1.Rows(), feature1.Cols(), gocv.MatTypeCV32F)
-    /*
-    fmt.Println(feature1.Cols())
-    fmt.Println(feature1.Rows())
-    fmt.Println(feature1.Channels())
-    fmt.Println(feature2.Cols())
-    fmt.Println(feature2.Rows())
-    fmt.Println(feature2.Channels())
-    fmt.Println(mask_1.Cols())
-    fmt.Println(mask_1.Rows())
-    fmt.Println(mask_1.Channels())
-*/
-    gocv.Rectangle(&mask_1, image.Rect(0, 0, mask_1.Cols(), mask_1.Rows()), color.RGBA{255, 255, 255,0}, -1)
+	result := gocv.NewMatWithSize(1, 1, gocv.MatTypeCV32F)
+	mask_1 := gocv.NewMatWithSize(feature1.Rows(), feature1.Cols(), gocv.MatTypeCV32F)
+	// fmt.Println(feature1.Cols())
+	// fmt.Println(feature1.Rows())
+	// fmt.Println(feature1.Channels())
+	// fmt.Println(feature2.Cols())
+	// fmt.Println(feature2.Rows())
+	// fmt.Println(feature2.Channels())
+	// fmt.Println(mask_1.Cols())
+	// fmt.Println(mask_1.Rows())
+	// fmt.Println(mask_1.Channels())
+	gocv.Rectangle(&mask_1, image.Rect(0, 0, mask_1.Cols(), mask_1.Rows()), color.RGBA{255, 255, 255, 0}, -1)
 
-    gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
-    //fmt.Print("lobby_matched: ")
-    //fmt.Print(result.GetFloatAt(0, 0))
+	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
+	// fmt.Print("lobby_matched: ")
+	// fmt.Print(result.GetFloatAt(0, 0))
 
-    done = true
+	done = true
 
-    return result.GetFloatAt(0, 0) < 100.0
+	return result.GetFloatAt(0, 0) < 100.0
 }
 
 func init() {
-    img := utils.IMRead720p("masks/spl2_lobby_matched.png")
-    feat_matched = Extract_feature(img)
+	img := utils.IMRead720p("masks/spl2_lobby_matched.png")
+	feat_matched = Extract_feature(img)
 }

--- a/src/scenes/lobby/lobby.go
+++ b/src/scenes/lobby/lobby.go
@@ -9,44 +9,44 @@ import (
 	"github.com/hasegaw/TakoLog/src/utils"
 )
 
-var feat_matched gocv.Mat
+var featMatched gocv.Mat
 var done = false
 
-func Extract_feature(img gocv.Mat) gocv.Mat {
-	img_win_bgr := img.Region(image.Rect(848, 32, 848+200, 32+32))
-	img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
-	img_win_v := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-	img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-	gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
-	gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
-	gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
+func ExtractFeature(img gocv.Mat) gocv.Mat {
+	imgWinBGR := img.Region(image.Rect(848, 32, 848+200, 32+32))
+	imgWinHSV := imgWinBGR.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
+	imgWinV := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	imgWinVNorm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+    gocv.CvtColor(imgWinBGR, &imgWinHSV, gocv.ColorBGRToHSV)
+	gocv.ExtractChannel(imgWinHSV, &imgWinV, 2)
+	gocv.Normalize(imgWinV, &imgWinVNorm, 0.0, 255.0, gocv.NormMinMax)
 
-	return img_win_v_norm
+	return imgWinVNorm
 }
 
-func Match_result(img gocv.Mat) bool {
+func MatchResult(img gocv.Mat) bool {
 	if done {
 		return false
 	}
 
 	img1 := img
-	feature1 := Extract_feature(img1)
-	feature2 := feat_matched
+	feature1 := ExtractFeature(img1)
+	feature2 := featMatched
 
 	result := gocv.NewMatWithSize(1, 1, gocv.MatTypeCV32F)
-	mask_1 := gocv.NewMatWithSize(feature1.Rows(), feature1.Cols(), gocv.MatTypeCV32F)
+	mask1 := gocv.NewMatWithSize(feature1.Rows(), feature1.Cols(), gocv.MatTypeCV32F)
 	// fmt.Println(feature1.Cols())
 	// fmt.Println(feature1.Rows())
 	// fmt.Println(feature1.Channels())
 	// fmt.Println(feature2.Cols())
 	// fmt.Println(feature2.Rows())
 	// fmt.Println(feature2.Channels())
-	// fmt.Println(mask_1.Cols())
-	// fmt.Println(mask_1.Rows())
-	// fmt.Println(mask_1.Channels())
-	gocv.Rectangle(&mask_1, image.Rect(0, 0, mask_1.Cols(), mask_1.Rows()), color.RGBA{255, 255, 255, 0}, -1)
+	// fmt.Println(mask1.Cols())
+	// fmt.Println(mask1.Rows())
+	// fmt.Println(mask1.Channels())
+	gocv.Rectangle(&mask1, image.Rect(0, 0, mask1.Cols(), mask1.Rows()), color.RGBA{255, 255, 255, 0}, -1)
 
-	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
+	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask1)
 	// fmt.Print("lobby_matched: ")
 	// fmt.Print(result.GetFloatAt(0, 0))
 
@@ -57,5 +57,5 @@ func Match_result(img gocv.Mat) bool {
 
 func init() {
 	img := utils.IMRead720p("masks/spl2_lobby_matched.png")
-	feat_matched = Extract_feature(img)
+	featMatched = ExtractFeature(img)
 }

--- a/src/scenes/lobby/lobby.go
+++ b/src/scenes/lobby/lobby.go
@@ -6,7 +6,7 @@ import (
     "image"
     "image/color"
 
-    "utils"
+    "github.com/hasegaw/TakoLog/src/utils"
 )
 
 var feat_matched gocv.Mat

--- a/src/scenes/result/result.go
+++ b/src/scenes/result/result.go
@@ -1,2 +1,1 @@
 package result
-

--- a/src/scenes/result/scoreboard/result_scorebord.go
+++ b/src/scenes/result/scoreboard/result_scorebord.go
@@ -1,34 +1,34 @@
 package scoreboard
 
 import (
-//    "fmt"
-    "gocv.io/x/gocv"
-    "image"
-    "image/color"
+	// "fmt"
+	"gocv.io/x/gocv"
+	"image"
+	"image/color"
 )
 
 func Extract_feature(img gocv.Mat) gocv.Mat {
-    img_win_bgr := img.Region(image.Rect(720, 80, 720 + 80, 80 + 32))
-    img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
-    img_win_v   := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-    img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-    gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
-    gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
-    gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
+	img_win_bgr := img.Region(image.Rect(720, 80, 720+80, 80+32))
+	img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
+	img_win_v := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
+	gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
+	gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
 
-    return img_win_v_norm
+	return img_win_v_norm
 }
 
 func Match_result(img gocv.Mat, img_template gocv.Mat) bool {
-    img1 := img
-    feature1 := Extract_feature(img1)
-    feature2 := img_template
+	img1 := img
+	feature1 := Extract_feature(img1)
+	feature2 := img_template
 
-    result := gocv.NewMatWithSize(2, 2, gocv.MatTypeCV32F)
-    mask_1 := gocv.NewMatWithSize(32, 80, gocv.MatTypeCV32F)
-    gocv.Rectangle(&mask_1,image.Rect(0, 0, 80, 32), color.RGBA{255, 255, 255,0}, -1)
+	result := gocv.NewMatWithSize(2, 2, gocv.MatTypeCV32F)
+	mask_1 := gocv.NewMatWithSize(32, 80, gocv.MatTypeCV32F)
+	gocv.Rectangle(&mask_1, image.Rect(0, 0, 80, 32), color.RGBA{255, 255, 255, 0}, -1)
 
-    gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
-    //fmt.Println(result.GetFloatAt(0, 0))
-    return result.GetFloatAt(0, 0) < 100.0
+	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
+	// fmt.Println(result.GetFloatAt(0, 0))
+	return result.GetFloatAt(0, 0) < 100.0
 }

--- a/src/scenes/result/scoreboard/result_scorebord.go
+++ b/src/scenes/result/scoreboard/result_scorebord.go
@@ -7,28 +7,28 @@ import (
 	"image/color"
 )
 
-func Extract_feature(img gocv.Mat) gocv.Mat {
-	img_win_bgr := img.Region(image.Rect(720, 80, 720+80, 80+32))
-	img_win_hsv := img_win_bgr.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
-	img_win_v := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-	img_win_v_norm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
-	gocv.CvtColor(img_win_bgr, &img_win_hsv, gocv.ColorBGRToHSV)
-	gocv.ExtractChannel(img_win_hsv, &img_win_v, 2)
-	gocv.Normalize(img_win_v, &img_win_v_norm, 0.0, 255.0, gocv.NormMinMax)
+func ExtractFeature(img gocv.Mat) gocv.Mat {
+	imgWinBGR := img.Region(image.Rect(720, 80, 720+80, 80+32))
+	imgWinHSV := imgWinBGR.Clone() // gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC3)
+	imgWinV := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	imgWinVNorm := gocv.NewMatWithSize(80, 32, gocv.MatTypeCV8UC1)
+	gocv.CvtColor(imgWinBGR, &imgWinHSV, gocv.ColorBGRToHSV)
+	gocv.ExtractChannel(imgWinHSV, &imgWinV, 2)
+	gocv.Normalize(imgWinV, &imgWinVNorm, 0.0, 255.0, gocv.NormMinMax)
 
-	return img_win_v_norm
+	return imgWinVNorm
 }
 
-func Match_result(img gocv.Mat, img_template gocv.Mat) bool {
+func MatchResult(img gocv.Mat, imgTemplate gocv.Mat) bool {
 	img1 := img
-	feature1 := Extract_feature(img1)
-	feature2 := img_template
+	feature1 := ExtractFeature(img1)
+	feature2 := imgTemplate
 
 	result := gocv.NewMatWithSize(2, 2, gocv.MatTypeCV32F)
-	mask_1 := gocv.NewMatWithSize(32, 80, gocv.MatTypeCV32F)
-	gocv.Rectangle(&mask_1, image.Rect(0, 0, 80, 32), color.RGBA{255, 255, 255, 0}, -1)
+	mask1 := gocv.NewMatWithSize(32, 80, gocv.MatTypeCV32F)
+	gocv.Rectangle(&mask1, image.Rect(0, 0, 80, 32), color.RGBA{255, 255, 255, 0}, -1)
 
-	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask_1)
+	gocv.MatchTemplate(feature1, feature2, &result, gocv.TmSqdiff, mask1)
 	// fmt.Println(result.GetFloatAt(0, 0))
 	return result.GetFloatAt(0, 0) < 100.0
 }

--- a/src/scenes/scenes.go
+++ b/src/scenes/scenes.go
@@ -1,5 +1,5 @@
 package scenes
 
 import (
-    "./result/scoreboard"
+	"./result/scoreboard"
 )

--- a/src/utils/result_scorebord.go
+++ b/src/utils/result_scorebord.go
@@ -1,14 +1,13 @@
 package utils
 
 import (
-    "image"
-    "gocv.io/x/gocv"
+	"gocv.io/x/gocv"
+	"image"
 )
 
-
 func IMRead720p(filename string) gocv.Mat {
-    img := gocv.IMRead(filename, gocv.IMReadColor)
-    img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
-    gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
-    return img_720p
+	img := gocv.IMRead(filename, gocv.IMReadColor)
+	img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
+	gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
+	return img_720p
 }

--- a/src/utils/result_scorebord.go
+++ b/src/utils/result_scorebord.go
@@ -7,7 +7,7 @@ import (
 
 func IMRead720p(filename string) gocv.Mat {
 	img := gocv.IMRead(filename, gocv.IMReadColor)
-	img_720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
-	gocv.Resize(img, &img_720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
-	return img_720p
+	img720p := gocv.NewMatWithSize(1280, 720, gocv.MatTypeCV8UC3)
+	gocv.Resize(img, &img720p, image.Point{1280, 720}, 0.0, 0.0, gocv.InterpolationLinear)
+	return img720p
 }


### PR DESCRIPTION
- Setup [Go Modules](https://github.com/golang/go/wiki/Modules)
- Code reformatted with `gofmt`. Fixed leading spaces, mainly.
- Rename identifier names from `snake_case` to `CamelCase`(public thing) or `camelCase`(private thing).